### PR TITLE
Adding tldextract as requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ toml==0.10.0
 urllib3==1.25.3
 virtualenv==16.7.2
 zipp==0.5.2
+tldextract==2.2.2


### PR DESCRIPTION
Adding rquired module in requirements.txt
tldextract is located in the log_channel module