### PR TITLE
feat: user tracking and welcome improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,16 @@ env/
 .idea/
 .vscode/
 .cursor/
+.zed/
 *.swp
 *.swo
+
+# AI / agent tooling
+.codex/
+.gemini/
+.mcp.json
+opencode.json
+electus/
 
 # OS
 .DS_Store

--- a/schema.sql
+++ b/schema.sql
@@ -64,3 +64,26 @@ CREATE TABLE IF NOT EXISTS global_bans (
     reason TEXT,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS known_users (
+    user_id BIGINT PRIMARY KEY,
+    username TEXT,
+    first_name TEXT,
+    last_name TEXT,
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_known_users_username
+    ON known_users (LOWER(username))
+    WHERE username IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS welcomed_users (
+    user_id BIGINT NOT NULL,
+    chat_id BIGINT NOT NULL,
+    welcomed_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (user_id, chat_id)
+);
+
+-- Add welcome_delay_minutes column to group_settings (idempotent).
+ALTER TABLE group_settings
+    ADD COLUMN IF NOT EXISTS welcome_delay_minutes INTEGER;

--- a/src/python_italy_bot/db/base.py
+++ b/src/python_italy_bot/db/base.py
@@ -2,6 +2,8 @@
 
 from abc import ABC, abstractmethod
 
+from .models import KnownUser
+
 
 class Repository(ABC):
     """Abstract interface for data persistence (sync)."""
@@ -136,6 +138,53 @@ class Repository(ABC):
         """Check if user is globally banned."""
         ...
 
+    # -- Known users (user tracking) --
+
+    @abstractmethod
+    def upsert_known_user(
+        self,
+        user_id: int,
+        username: str | None,
+        first_name: str | None,
+        last_name: str | None,
+    ) -> None:
+        """Insert or update a known user's info."""
+        ...
+
+    @abstractmethod
+    def get_known_user(self, user_id: int) -> KnownUser | None:
+        """Get a known user by ID."""
+        ...
+
+    @abstractmethod
+    def get_known_user_by_username(self, username: str) -> KnownUser | None:
+        """Get a known user by username (case-insensitive)."""
+        ...
+
+    # -- Welcomed users (welcome-once-per-group) --
+
+    @abstractmethod
+    def has_been_welcomed(self, user_id: int, chat_id: int) -> bool:
+        """Check if user has already been welcomed in this chat."""
+        ...
+
+    @abstractmethod
+    def mark_welcomed(self, user_id: int, chat_id: int) -> None:
+        """Mark user as having been welcomed in this chat."""
+        ...
+
+    # -- Welcome delay --
+
+    @abstractmethod
+    def get_welcome_delay(self, chat_id: int) -> int | None:
+        """Get welcome message auto-delete delay in minutes for a chat."""
+        ...
+
+    @abstractmethod
+    def set_welcome_delay(self, chat_id: int, minutes: int | None) -> None:
+        """Set welcome message auto-delete delay. None to reset to default."""
+        ...
+
 
 class AsyncRepository(ABC):
     """Abstract interface for data persistence (async)."""
@@ -268,6 +317,53 @@ class AsyncRepository(ABC):
     @abstractmethod
     async def is_globally_banned(self, user_id: int) -> bool:
         """Check if user is globally banned."""
+        ...
+
+    # -- Known users (user tracking) --
+
+    @abstractmethod
+    async def upsert_known_user(
+        self,
+        user_id: int,
+        username: str | None,
+        first_name: str | None,
+        last_name: str | None,
+    ) -> None:
+        """Insert or update a known user's info."""
+        ...
+
+    @abstractmethod
+    async def get_known_user(self, user_id: int) -> KnownUser | None:
+        """Get a known user by ID."""
+        ...
+
+    @abstractmethod
+    async def get_known_user_by_username(self, username: str) -> KnownUser | None:
+        """Get a known user by username (case-insensitive)."""
+        ...
+
+    # -- Welcomed users (welcome-once-per-group) --
+
+    @abstractmethod
+    async def has_been_welcomed(self, user_id: int, chat_id: int) -> bool:
+        """Check if user has already been welcomed in this chat."""
+        ...
+
+    @abstractmethod
+    async def mark_welcomed(self, user_id: int, chat_id: int) -> None:
+        """Mark user as having been welcomed in this chat."""
+        ...
+
+    # -- Welcome delay --
+
+    @abstractmethod
+    async def get_welcome_delay(self, chat_id: int) -> int | None:
+        """Get welcome message auto-delete delay in minutes for a chat."""
+        ...
+
+    @abstractmethod
+    async def set_welcome_delay(self, chat_id: int, minutes: int | None) -> None:
+        """Set welcome message auto-delete delay. None to reset to default."""
         ...
 
     async def close(self) -> None:

--- a/src/python_italy_bot/db/in_memory.py
+++ b/src/python_italy_bot/db/in_memory.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 
 from .base import AsyncRepository
-from .models import Ban, Mute, Report
+from .models import Ban, KnownUser, Mute, Report
 
 
 class InMemoryRepository(AsyncRepository):
@@ -19,6 +19,10 @@ class InMemoryRepository(AsyncRepository):
         self._globally_verified: set[int] = set()
         self._bot_chats: set[int] = set()
         self._global_bans: dict[int, tuple[int, str | None]] = {}
+        self._known_users: dict[int, KnownUser] = {}
+        self._username_to_user_id: dict[str, int] = {}
+        self._welcomed: set[tuple[int, int]] = set()
+        self._welcome_delays: dict[int, int] = {}
 
     async def add_pending_verification(self, user_id: int, chat_id: int) -> None:
         self._pending.add((user_id, chat_id))
@@ -159,3 +163,54 @@ class InMemoryRepository(AsyncRepository):
 
     async def is_globally_banned(self, user_id: int) -> bool:
         return user_id in self._global_bans
+
+    # -- Known users --
+
+    async def upsert_known_user(
+        self,
+        user_id: int,
+        username: str | None,
+        first_name: str | None,
+        last_name: str | None,
+    ) -> None:
+        old = self._known_users.get(user_id)
+        if old and old.username:
+            self._username_to_user_id.pop(old.username.lower(), None)
+        user = KnownUser(
+            user_id=user_id,
+            username=username,
+            first_name=first_name,
+            last_name=last_name,
+            updated_at=datetime.now(timezone.utc),
+        )
+        self._known_users[user_id] = user
+        if username:
+            self._username_to_user_id[username.lower()] = user_id
+
+    async def get_known_user(self, user_id: int) -> KnownUser | None:
+        return self._known_users.get(user_id)
+
+    async def get_known_user_by_username(self, username: str) -> KnownUser | None:
+        uid = self._username_to_user_id.get(username.lower())
+        if uid is not None:
+            return self._known_users.get(uid)
+        return None
+
+    # -- Welcomed users --
+
+    async def has_been_welcomed(self, user_id: int, chat_id: int) -> bool:
+        return (user_id, chat_id) in self._welcomed
+
+    async def mark_welcomed(self, user_id: int, chat_id: int) -> None:
+        self._welcomed.add((user_id, chat_id))
+
+    # -- Welcome delay --
+
+    async def get_welcome_delay(self, chat_id: int) -> int | None:
+        return self._welcome_delays.get(chat_id)
+
+    async def set_welcome_delay(self, chat_id: int, minutes: int | None) -> None:
+        if minutes is None:
+            self._welcome_delays.pop(chat_id, None)
+        else:
+            self._welcome_delays[chat_id] = minutes

--- a/src/python_italy_bot/db/models.py
+++ b/src/python_italy_bot/db/models.py
@@ -5,6 +5,17 @@ from datetime import datetime
 
 
 @dataclass
+class KnownUser:
+    """A user the bot has interacted with."""
+
+    user_id: int
+    username: str | None
+    first_name: str | None
+    last_name: str | None
+    updated_at: datetime
+
+
+@dataclass
 class Ban:
     """A user ban in a chat."""
 

--- a/src/python_italy_bot/db/postgres.py
+++ b/src/python_italy_bot/db/postgres.py
@@ -3,6 +3,7 @@
 from psycopg_pool import AsyncConnectionPool
 
 from .base import AsyncRepository
+from .models import KnownUser
 
 
 class PostgresRepository(AsyncRepository):
@@ -260,6 +261,123 @@ class PostgresRepository(AsyncRepository):
                     (user_id,),
                 )
                 return await cur.fetchone() is not None
+
+    # -- Known users --
+
+    async def upsert_known_user(
+        self,
+        user_id: int,
+        username: str | None,
+        first_name: str | None,
+        last_name: str | None,
+    ) -> None:
+        async with self._pool.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO known_users (user_id, username, first_name, last_name, updated_at)
+                VALUES (%s, %s, %s, %s, NOW())
+                ON CONFLICT (user_id)
+                DO UPDATE SET username = EXCLUDED.username,
+                              first_name = EXCLUDED.first_name,
+                              last_name = EXCLUDED.last_name,
+                              updated_at = NOW()
+                """,
+                (user_id, username, first_name, last_name),
+            )
+
+    async def get_known_user(self, user_id: int) -> KnownUser | None:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT user_id, username, first_name, last_name, updated_at "
+                    "FROM known_users WHERE user_id = %s",
+                    (user_id,),
+                )
+                row = await cur.fetchone()
+                if row is None:
+                    return None
+                return KnownUser(
+                    user_id=row[0],
+                    username=row[1],
+                    first_name=row[2],
+                    last_name=row[3],
+                    updated_at=row[4],
+                )
+
+    async def get_known_user_by_username(self, username: str) -> KnownUser | None:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT user_id, username, first_name, last_name, updated_at "
+                    "FROM known_users WHERE LOWER(username) = LOWER(%s)",
+                    (username,),
+                )
+                row = await cur.fetchone()
+                if row is None:
+                    return None
+                return KnownUser(
+                    user_id=row[0],
+                    username=row[1],
+                    first_name=row[2],
+                    last_name=row[3],
+                    updated_at=row[4],
+                )
+
+    # -- Welcomed users --
+
+    async def has_been_welcomed(self, user_id: int, chat_id: int) -> bool:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT 1 FROM welcomed_users WHERE user_id = %s AND chat_id = %s",
+                    (user_id, chat_id),
+                )
+                return await cur.fetchone() is not None
+
+    async def mark_welcomed(self, user_id: int, chat_id: int) -> None:
+        async with self._pool.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO welcomed_users (user_id, chat_id)
+                VALUES (%s, %s)
+                ON CONFLICT (user_id, chat_id) DO NOTHING
+                """,
+                (user_id, chat_id),
+            )
+
+    # -- Welcome delay --
+
+    async def get_welcome_delay(self, chat_id: int) -> int | None:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT welcome_delay_minutes FROM group_settings WHERE chat_id = %s",
+                    (chat_id,),
+                )
+                row = await cur.fetchone()
+                return row[0] if row else None
+
+    async def set_welcome_delay(self, chat_id: int, minutes: int | None) -> None:
+        async with self._pool.connection() as conn:
+            if minutes is None:
+                await conn.execute(
+                    """
+                    UPDATE group_settings SET welcome_delay_minutes = NULL, updated_at = NOW()
+                    WHERE chat_id = %s
+                    """,
+                    (chat_id,),
+                )
+            else:
+                await conn.execute(
+                    """
+                    INSERT INTO group_settings (chat_id, welcome_delay_minutes, updated_at)
+                    VALUES (%s, %s, NOW())
+                    ON CONFLICT (chat_id)
+                    DO UPDATE SET welcome_delay_minutes = EXCLUDED.welcome_delay_minutes,
+                                  updated_at = NOW()
+                    """,
+                    (chat_id, minutes),
+                )
 
     async def close(self) -> None:
         await self._pool.close()

--- a/src/python_italy_bot/handlers/moderation.py
+++ b/src/python_italy_bot/handlers/moderation.py
@@ -623,6 +623,13 @@ async def _resolve_user_id(
             known = await moderation_service.get_known_user_by_username(username_lower)
             if known is not None:
                 return known.user_id
+        # Try Telegram API as last resort
+        try:
+            resolved_chat = await context.bot.get_chat(f"@{username_lower}")
+            if resolved_chat.id:
+                return resolved_chat.id
+        except Exception:
+            pass
         return None
     if re.match(r"^-?\d+$", target):
         return int(target)

--- a/src/python_italy_bot/handlers/moderation.py
+++ b/src/python_italy_bot/handlers/moderation.py
@@ -14,16 +14,6 @@ from ..services.moderation import ModerationService
 logger = logging.getLogger(__name__)
 
 
-async def _track_user(repo: AsyncRepository, user: object) -> None:
-    """Track a Telegram user in the known_users table."""
-    await repo.upsert_known_user(
-        user_id=user.id,  # type: ignore[attr-defined]
-        username=getattr(user, "username", None),
-        first_name=getattr(user, "first_name", None),
-        last_name=getattr(user, "last_name", None),
-    )
-
-
 async def _is_admin(
     context: ContextTypes.DEFAULT_TYPE, chat_id: int, user_id: int
 ) -> bool:
@@ -81,7 +71,6 @@ async def _handle_force_group_registration(
 async def _handle_ban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Ban a user globally. Usage: /ban user_id|@username [reason] or reply with /ban [reason]."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
-    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -89,9 +78,6 @@ async def _handle_ban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
-
-    # Track the invoking admin
-    await _track_user(repository, message.from_user)
 
     if not await _is_admin(context, chat.id, message.from_user.id):
         await message.reply_text(strings.ONLY_ADMINS)
@@ -152,7 +138,6 @@ async def _handle_ban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 async def _handle_unban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Unban a user globally. Usage: /unban user_id or reply to message with /unban."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
-    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -160,9 +145,6 @@ async def _handle_unban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
-
-    # Track the invoking admin
-    await _track_user(repository, message.from_user)
 
     if not await _is_admin(context, chat.id, message.from_user.id):
         await message.reply_text(strings.ONLY_ADMINS)
@@ -197,7 +179,6 @@ async def _handle_unban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 async def _handle_mute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Mute a user. Usage: /mute @username [duration_minutes] [reason]."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
-    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -205,9 +186,6 @@ async def _handle_mute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
-
-    # Track the invoking admin
-    await _track_user(repository, message.from_user)
 
     if not await _is_admin(context, chat.id, message.from_user.id):
         await message.reply_text(strings.ONLY_ADMINS)
@@ -270,7 +248,6 @@ async def _handle_mute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 async def _handle_unmute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Unmute a user. Usage: /unmute @username."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
-    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -278,9 +255,6 @@ async def _handle_unmute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
-
-    # Track the invoking admin
-    await _track_user(repository, message.from_user)
 
     if not await _is_admin(context, chat.id, message.from_user.id):
         await message.reply_text(strings.ONLY_ADMINS)
@@ -329,7 +303,6 @@ async def _handle_unmute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 async def _handle_report(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Report a message or user. Usage: /report [reason] or reply to message with /report [reason]."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
-    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -337,9 +310,6 @@ async def _handle_report(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
-
-    # Track the reporter
-    await _track_user(repository, message.from_user)
 
     args = message.text.split(maxsplit=1)[1:] if message.text else []
     reason = args[0] if args else None
@@ -387,7 +357,6 @@ async def _handle_admin_mention(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     """Handle @admin mention: notify admins of intervention request (no reply needed)."""
-    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -395,9 +364,6 @@ async def _handle_admin_mention(
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
-
-    # Track the user
-    await _track_user(repository, message.from_user)
 
     text = message.text or message.caption or ""
     reason = _extract_reason_after_admin(text)

--- a/src/python_italy_bot/handlers/moderation.py
+++ b/src/python_italy_bot/handlers/moderation.py
@@ -8,9 +8,20 @@ from telegram.constants import ChatMemberStatus
 from telegram.ext import CommandHandler, ContextTypes, MessageHandler, filters
 
 from .. import strings
+from ..db.base import AsyncRepository
 from ..services.moderation import ModerationService
 
 logger = logging.getLogger(__name__)
+
+
+async def _track_user(repo: AsyncRepository, user: object) -> None:
+    """Track a Telegram user in the known_users table."""
+    await repo.upsert_known_user(
+        user_id=user.id,  # type: ignore[attr-defined]
+        username=getattr(user, "username", None),
+        first_name=getattr(user, "first_name", None),
+        last_name=getattr(user, "last_name", None),
+    )
 
 
 async def _is_admin(
@@ -68,8 +79,9 @@ async def _handle_force_group_registration(
 
 
 async def _handle_ban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Ban a user globally. Usage: /ban user_id [reason] or reply to message with /ban [reason]"""
+    """Ban a user globally. Usage: /ban user_id|@username [reason] or reply with /ban [reason]."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
+    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -77,6 +89,9 @@ async def _handle_ban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
+
+    # Track the invoking admin
+    await _track_user(repository, message.from_user)
 
     if not await _is_admin(context, chat.id, message.from_user.id):
         await message.reply_text(strings.ONLY_ADMINS)
@@ -86,13 +101,22 @@ async def _handle_ban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
     user_id: int | None = None
     reason: str | None = None
-    if message.reply_to_message and message.reply_to_message.from_user:
-        user_id = message.reply_to_message.from_user.id
+    if message.reply_to_message:
+        reply = message.reply_to_message
+        if reply.from_user and not reply.from_user.is_bot:
+            # Replying to a regular user's message
+            user_id = reply.from_user.id
+        else:
+            # Replying to a bot message — check welcome_message_map
+            welcome_map: dict[tuple[int, int], int] = context.bot_data.get(
+                "welcome_message_map", {}
+            )
+            user_id = welcome_map.get((chat.id, reply.message_id))
         reason = " ".join(args) if args else None
     elif args:
         target = args[0]
         reason = args[1] if len(args) > 1 else None
-        user_id = await _resolve_user_id(context, chat.id, target)
+        user_id = await _resolve_user_id(context, chat.id, target, moderation_service)
 
     if user_id is None:
         await message.reply_text(strings.BAN_USAGE)
@@ -114,10 +138,21 @@ async def _handle_ban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
     await message.reply_text(strings.ban_success(success_count, fail_count, reason))
 
+    # Notify admins of the ban
+    await _notify_admins_of_ban(
+        context=context,
+        chat=chat,
+        admin=message.from_user,
+        banned_user_id=user_id,
+        success_count=success_count,
+        reason=reason,
+    )
+
 
 async def _handle_unban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Unban a user globally. Usage: /unban user_id or reply to message with /unban"""
+    """Unban a user globally. Usage: /unban user_id or reply to message with /unban."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
+    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -125,6 +160,9 @@ async def _handle_unban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
+
+    # Track the invoking admin
+    await _track_user(repository, message.from_user)
 
     if not await _is_admin(context, chat.id, message.from_user.id):
         await message.reply_text(strings.ONLY_ADMINS)
@@ -135,7 +173,7 @@ async def _handle_unban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     if message.reply_to_message and message.reply_to_message.from_user:
         user_id = message.reply_to_message.from_user.id
     elif args:
-        user_id = await _resolve_user_id(context, chat.id, args[0])
+        user_id = await _resolve_user_id(context, chat.id, args[0], moderation_service)
 
     if user_id is None:
         await message.reply_text(strings.UNBAN_USAGE)
@@ -157,8 +195,9 @@ async def _handle_unban(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
 
 async def _handle_mute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Mute a user. Usage: /mute @username [duration_minutes] [reason]"""
+    """Mute a user. Usage: /mute @username [duration_minutes] [reason]."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
+    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -166,6 +205,9 @@ async def _handle_mute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
+
+    # Track the invoking admin
+    await _track_user(repository, message.from_user)
 
     if not await _is_admin(context, chat.id, message.from_user.id):
         await message.reply_text(strings.ONLY_ADMINS)
@@ -191,7 +233,7 @@ async def _handle_mute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             reason = args[2] if len(args) > 2 else None
         else:
             reason = args[1] if len(args) > 1 else None
-        user_id = await _resolve_user_id(context, chat.id, target)
+        user_id = await _resolve_user_id(context, chat.id, target, moderation_service)
 
     if user_id is None:
         await message.reply_text(strings.MUTE_USAGE)
@@ -226,8 +268,9 @@ async def _handle_mute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 
 async def _handle_unmute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Unmute a user. Usage: /unmute @username"""
+    """Unmute a user. Usage: /unmute @username."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
+    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -235,6 +278,9 @@ async def _handle_unmute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
+
+    # Track the invoking admin
+    await _track_user(repository, message.from_user)
 
     if not await _is_admin(context, chat.id, message.from_user.id):
         await message.reply_text(strings.ONLY_ADMINS)
@@ -245,7 +291,7 @@ async def _handle_unmute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     if message.reply_to_message and message.reply_to_message.from_user:
         user_id = message.reply_to_message.from_user.id
     elif args:
-        user_id = await _resolve_user_id(context, chat.id, args[0])
+        user_id = await _resolve_user_id(context, chat.id, args[0], moderation_service)
 
     if user_id is None:
         await message.reply_text(strings.UNMUTE_USAGE)
@@ -281,8 +327,9 @@ async def _handle_unmute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 
 async def _handle_report(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Report a message or user. Usage: /report [reason] or reply to message with /report [reason]"""
+    """Report a message or user. Usage: /report [reason] or reply to message with /report [reason]."""
     moderation_service: ModerationService = context.bot_data["moderation_service"]
+    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -290,6 +337,9 @@ async def _handle_report(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
+
+    # Track the reporter
+    await _track_user(repository, message.from_user)
 
     args = message.text.split(maxsplit=1)[1:] if message.text else []
     reason = args[0] if args else None
@@ -337,6 +387,7 @@ async def _handle_admin_mention(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     """Handle @admin mention: notify admins of intervention request (no reply needed)."""
+    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.from_user is None:
         return
@@ -344,6 +395,9 @@ async def _handle_admin_mention(
     chat = update.effective_chat
     if chat is None or chat.type == "private":
         return
+
+    # Track the user
+    await _track_user(repository, message.from_user)
 
     text = message.text or message.caption or ""
     reason = _extract_reason_after_admin(text)
@@ -474,8 +528,67 @@ async def _notify_admins_of_report(
                 parse_mode="HTML",
             )
         except Exception as e:
+            logger.debug("Could not send report to admin %s: %s", admin.user.id, e)
+
+
+async def _notify_admins_of_ban(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat,
+    admin,
+    banned_user_id: int,
+    success_count: int,
+    reason: str | None,
+) -> None:
+    """Send ban notification to all chat admins via private message."""
+    try:
+        chat_admins = await context.bot.get_chat_administrators(chat.id)
+    except Exception as e:
+        logger.warning("Failed to get admins for ban notification: %s", e)
+        return
+
+    chat_title = chat.title or "Chat"
+    admin_name = _get_user_display_name(admin)
+
+    # Try to get banned user display name from known_users
+    banned_name = str(banned_user_id)
+    repository: AsyncRepository | None = context.bot_data.get("repository")
+    if repository is not None:
+        known_user = await repository.get_known_user(banned_user_id)
+        if known_user is not None:
+            if known_user.first_name:
+                banned_name = known_user.first_name
+                if known_user.last_name:
+                    banned_name += f" {known_user.last_name}"
+            elif known_user.username:
+                banned_name = f"@{known_user.username}"
+
+    notification = strings.ban_notification(
+        chat_title=chat_title,
+        banned_name=banned_name,
+        banned_id=banned_user_id,
+        admin_name=admin_name,
+        admin_id=admin.id,
+        success_count=success_count,
+        reason=reason,
+    )
+
+    for member in chat_admins:
+        if member.user.is_bot:
+            continue
+        # Don't notify the admin who performed the ban
+        if member.user.id == admin.id:
+            continue
+        try:
+            await context.bot.send_message(
+                chat_id=member.user.id,
+                text=notification,
+                parse_mode="HTML",
+            )
+        except Exception as e:
             logger.debug(
-                "Could not send report to admin %s: %s", admin.user.id, e
+                "Could not send ban notification to admin %s: %s",
+                member.user.id,
+                e,
             )
 
 
@@ -483,22 +596,34 @@ async def _resolve_user_id(
     context: ContextTypes.DEFAULT_TYPE,
     chat_id: int,
     target: str,
+    moderation_service: ModerationService | None = None,
 ) -> int | None:
-    """Resolve @username or user_id to numeric user_id. @username only works for admins."""
+    """Resolve @username or user_id to numeric user_id.
+
+    Resolution order for @username:
+    1. Check chat administrators (works for admins only).
+    2. Fall back to known_users table (any user the bot has seen).
+    """
     target = target.strip()
     if target.startswith("@"):
+        username_lower = target.lstrip("@").lower()
+        # Try admins first
         try:
             admins = await context.bot.get_chat_administrators(chat_id)
-            username_lower = target.lstrip("@").lower()
             for admin in admins:
                 if (
                     admin.user.username
                     and admin.user.username.lower() == username_lower
                 ):
                     return admin.user.id
-            return None
         except Exception:
-            return None
+            pass
+        # Fall back to known_users table
+        if moderation_service is not None:
+            known = await moderation_service.get_known_user_by_username(username_lower)
+            if known is not None:
+                return known.user_id
+        return None
     if re.match(r"^-?\d+$", target):
         return int(target)
     return None

--- a/src/python_italy_bot/handlers/settings.py
+++ b/src/python_italy_bot/handlers/settings.py
@@ -32,6 +32,8 @@ def create_settings_handlers() -> list:
         CommandHandler("setwelcome", _handle_setwelcome),
         CommandHandler("resetwelcome", _handle_resetwelcome),
         CommandHandler("getwelcome", _handle_getwelcome),
+        CommandHandler("setwelcomedelay", _handle_setwelcomedelay),
+        CommandHandler("getwelcomedelay", _handle_getwelcomedelay),
     ]
 
 
@@ -39,13 +41,13 @@ async def _handle_setwelcome(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     """Set custom welcome message for the group.
-    
+
     Usage: /setwelcome <message>
-    
+
     Supports placeholders:
       - {username}: @username or full name
       - {chatname}: group name
-    
+
     Supports button syntax:
       - [Button Text](buttonurl://URL)
     """
@@ -134,6 +136,74 @@ async def _handle_getwelcome(
     else:
         bot_username = (await context.bot.get_me()).username or "bot"
         default = captcha_service.get_default_welcome_template(bot_username)
+        await message.reply_text(strings.GETWELCOME_DEFAULT.format(message=default))
+
+
+async def _handle_setwelcomedelay(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Set auto-delete delay for welcome messages. Usage: /setwelcomedelay <minutes>."""
+    captcha_service: CaptchaService = context.bot_data["captcha_service"]
+    message = update.message
+    if message is None or message.from_user is None:
+        return
+
+    chat = update.effective_chat
+    if chat is None or chat.type == "private":
+        await message.reply_text(strings.ONLY_IN_GROUPS)
+        return
+
+    if not await _is_admin(context, chat.id, message.from_user.id):
+        await message.reply_text(strings.ONLY_ADMINS)
+        return
+
+    if message.text is None:
+        return
+
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2 or not parts[1].strip().isdigit():
+        await message.reply_text(strings.SETWELCOMEDELAY_USAGE)
+        return
+
+    minutes = int(parts[1].strip())
+
+    if minutes == 0:
+        await captcha_service.set_welcome_delay(chat.id, 0)
+        await message.reply_text(strings.SETWELCOMEDELAY_DISABLED)
+    else:
+        await captcha_service.set_welcome_delay(chat.id, minutes)
         await message.reply_text(
-            strings.GETWELCOME_DEFAULT.format(message=default)
+            strings.SETWELCOMEDELAY_SUCCESS.format(minutes=minutes)
         )
+
+    logger.info(
+        "Welcome delay set to %s min for chat %s by admin %s",
+        minutes,
+        chat.id,
+        message.from_user.id,
+    )
+
+
+async def _handle_getwelcomedelay(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Show current auto-delete delay for welcome messages."""
+    captcha_service: CaptchaService = context.bot_data["captcha_service"]
+    message = update.message
+    if message is None or message.from_user is None:
+        return
+
+    chat = update.effective_chat
+    if chat is None or chat.type == "private":
+        await message.reply_text(strings.ONLY_IN_GROUPS)
+        return
+
+    if not await _is_admin(context, chat.id, message.from_user.id):
+        await message.reply_text(strings.ONLY_ADMINS)
+        return
+
+    delay = await captcha_service.get_welcome_delay(chat.id)
+    if delay is not None:
+        await message.reply_text(strings.GETWELCOMEDELAY_RESPONSE.format(minutes=delay))
+    else:
+        await message.reply_text(strings.GETWELCOMEDELAY_DEFAULT)

--- a/src/python_italy_bot/handlers/utils.py
+++ b/src/python_italy_bot/handlers/utils.py
@@ -1,0 +1,41 @@
+"""Shared utilities for all handlers."""
+
+import logging
+
+from telegram import Update
+from telegram.ext import ContextTypes, TypeHandler
+
+from ..db.base import AsyncRepository
+
+logger = logging.getLogger(__name__)
+
+
+async def track_user(repo: AsyncRepository, user: object) -> None:
+    """Track a Telegram user in the known_users table."""
+    await repo.upsert_known_user(
+        user_id=user.id,  # type: ignore[attr-defined]
+        username=getattr(user, "username", None),
+        first_name=getattr(user, "first_name", None),
+        last_name=getattr(user, "last_name", None),
+    )
+
+
+async def _handle_track_user(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Middleware: track the effective user for every update."""
+    user = update.effective_user
+    if user is None:
+        return
+    repository: AsyncRepository | None = context.bot_data.get("repository")
+    if repository is None:
+        return
+    try:
+        await track_user(repository, user)
+    except Exception as e:
+        logger.warning("Failed to track user %s: %s", user.id, e, exc_info=True)
+
+
+def create_user_tracking_handler() -> TypeHandler:
+    """Create a TypeHandler that tracks users from every incoming update."""
+    return TypeHandler(Update, _handle_track_user)

--- a/src/python_italy_bot/handlers/welcome.py
+++ b/src/python_italy_bot/handlers/welcome.py
@@ -16,20 +16,11 @@ from .. import strings
 from ..db.base import AsyncRepository
 from ..services.captcha import CaptchaService
 from ..services.moderation import ModerationService
+from .utils import track_user
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_WELCOME_DELAY_MINUTES = 5
-
-
-async def _track_user(repo: AsyncRepository, user: object) -> None:
-    """Track a Telegram user in the known_users table."""
-    await repo.upsert_known_user(
-        user_id=user.id,  # type: ignore[attr-defined]
-        username=getattr(user, "username", None),
-        first_name=getattr(user, "first_name", None),
-        last_name=getattr(user, "last_name", None),
-    )
 
 
 def create_welcome_handlers(captcha_service: CaptchaService) -> list:
@@ -93,8 +84,9 @@ async def _handle_new_member(
 
     await moderation_service.register_chat(chat.id)
 
-    # Track the user
-    await _track_user(repository, user)
+    # Track the new member explicitly: middleware tracks effective_user (the admin
+    # when someone is added by an admin), but we need to track the joined member.
+    await track_user(repository, user)
 
     if user.is_bot:
         return
@@ -176,7 +168,6 @@ async def _handle_start(
 ) -> None:
     """Handle /start command, including deep link for verification."""
     captcha_service: CaptchaService = context.bot_data["captcha_service"]
-    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None:
         return
@@ -188,9 +179,6 @@ async def _handle_start(
     user = update.effective_user
     if user is None:
         return
-
-    # Track the user
-    await _track_user(repository, user)
 
     args = context.args
     if args and args[0] == "verify":
@@ -254,7 +242,6 @@ async def _handle_private_message(
 ) -> None:
     """Handle private messages: check for secret command and verify user globally."""
     captcha_service: CaptchaService = context.bot_data["captcha_service"]
-    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.text is None:
         return
@@ -262,9 +249,6 @@ async def _handle_private_message(
     user = update.effective_user
     if user is None:
         return
-
-    # Track the user
-    await _track_user(repository, user)
 
     if not captcha_service.is_secret_command(message.text):
         await message.reply_text(strings.VERIFY_UNKNOWN_COMMAND)

--- a/src/python_italy_bot/handlers/welcome.py
+++ b/src/python_italy_bot/handlers/welcome.py
@@ -13,10 +13,23 @@ from telegram.ext import (
 )
 
 from .. import strings
+from ..db.base import AsyncRepository
 from ..services.captcha import CaptchaService
 from ..services.moderation import ModerationService
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_WELCOME_DELAY_MINUTES = 5
+
+
+async def _track_user(repo: AsyncRepository, user: object) -> None:
+    """Track a Telegram user in the known_users table."""
+    await repo.upsert_known_user(
+        user_id=user.id,  # type: ignore[attr-defined]
+        username=getattr(user, "username", None),
+        first_name=getattr(user, "first_name", None),
+        last_name=getattr(user, "last_name", None),
+    )
 
 
 def create_welcome_handlers(captcha_service: CaptchaService) -> list:
@@ -34,6 +47,21 @@ def create_welcome_handlers(captcha_service: CaptchaService) -> list:
     ]
 
 
+async def _delete_welcome_message(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Job callback: delete a welcome message after the configured delay."""
+    job = context.job
+    if job is None or job.data is None:
+        return
+    data: tuple[int, int] = job.data  # type: ignore[assignment]
+    chat_id, message_id = data
+    try:
+        await context.bot.delete_message(chat_id=chat_id, message_id=message_id)
+    except Exception as e:
+        logger.debug(
+            "Could not delete welcome message %s in chat %s: %s", message_id, chat_id, e
+        )
+
+
 async def _handle_new_member(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
@@ -41,6 +69,7 @@ async def _handle_new_member(
     """Handle new chat members: restrict and send welcome with captcha instructions."""
     captcha_service: CaptchaService = context.bot_data["captcha_service"]
     moderation_service: ModerationService = context.bot_data["moderation_service"]
+    repository: AsyncRepository = context.bot_data["repository"]
     result = update.chat_member
     if result is None:
         return
@@ -63,6 +92,9 @@ async def _handle_new_member(
         return
 
     await moderation_service.register_chat(chat.id)
+
+    # Track the user
+    await _track_user(repository, user)
 
     if user.is_bot:
         return
@@ -90,6 +122,10 @@ async def _handle_new_member(
 
     await captcha_service.add_pending(user.id, chat.id)
 
+    # Skip welcome if user was already welcomed in this chat
+    if await captcha_service.has_been_welcomed(user.id, chat.id):
+        return
+
     bot_me = await context.bot.get_me()
     bot_username = bot_me.username or "bot"
 
@@ -99,17 +135,39 @@ async def _handle_new_member(
     else:
         template = captcha_service.get_default_welcome_template(bot_username)
 
-    formatted = captcha_service.format_welcome_message(template, user, chat, bot_username)
+    formatted = captcha_service.format_welcome_message(
+        template, user, chat, bot_username
+    )
     text, keyboard = captcha_service.parse_button_urls(formatted)
 
     try:
-        await context.bot.send_message(
+        sent = await context.bot.send_message(
             chat_id=chat.id,
             text=text,
             reply_markup=keyboard,
         )
     except Exception as e:
         logger.warning("Could not send welcome to chat %s: %s", chat.id, e)
+        return
+
+    # Mark user as welcomed in this chat
+    await captcha_service.mark_welcomed(user.id, chat.id)
+
+    # Store welcome message -> user mapping for ban-by-reply
+    welcome_map = context.bot_data.setdefault("welcome_message_map", {})
+    welcome_map[(chat.id, sent.message_id)] = user.id
+
+    # Schedule auto-deletion of the welcome message
+    delay_minutes = await captcha_service.get_welcome_delay(chat.id)
+    if delay_minutes is None:
+        delay_minutes = DEFAULT_WELCOME_DELAY_MINUTES
+    if delay_minutes > 0 and context.job_queue is not None:
+        context.job_queue.run_once(
+            _delete_welcome_message,
+            when=delay_minutes * 60,
+            data=(chat.id, sent.message_id),
+            name=f"del_welcome_{chat.id}_{sent.message_id}",
+        )
 
 
 async def _handle_start(
@@ -118,6 +176,7 @@ async def _handle_start(
 ) -> None:
     """Handle /start command, including deep link for verification."""
     captcha_service: CaptchaService = context.bot_data["captcha_service"]
+    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None:
         return
@@ -129,6 +188,9 @@ async def _handle_start(
     user = update.effective_user
     if user is None:
         return
+
+    # Track the user
+    await _track_user(repository, user)
 
     args = context.args
     if args and args[0] == "verify":
@@ -192,6 +254,7 @@ async def _handle_private_message(
 ) -> None:
     """Handle private messages: check for secret command and verify user globally."""
     captcha_service: CaptchaService = context.bot_data["captcha_service"]
+    repository: AsyncRepository = context.bot_data["repository"]
     message = update.message
     if message is None or message.text is None:
         return
@@ -199,6 +262,9 @@ async def _handle_private_message(
     user = update.effective_user
     if user is None:
         return
+
+    # Track the user
+    await _track_user(repository, user)
 
     if not captcha_service.is_secret_command(message.text):
         await message.reply_text(strings.VERIFY_UNKNOWN_COMMAND)

--- a/src/python_italy_bot/main.py
+++ b/src/python_italy_bot/main.py
@@ -12,6 +12,7 @@ from .handlers.moderation import create_moderation_handlers
 from .handlers.ping import create_ping_handlers
 from .handlers.settings import create_settings_handlers
 # from .handlers.spam import create_spam_handler
+from .handlers.utils import create_user_tracking_handler
 from .handlers.welcome import create_welcome_handlers
 from .services.captcha import CaptchaService
 from .services.moderation import ModerationService
@@ -42,6 +43,9 @@ async def _post_init(application) -> None:
     application.bot_data["captcha_service"] = captcha_service
     application.bot_data["moderation_service"] = moderation_service
     # application.bot_data["spam_detector"] = spam_detector
+
+    # Register user-tracking middleware before all other handlers (group -1)
+    application.add_handler(create_user_tracking_handler(), group=-1)
 
     for handler in create_id_handlers():
         application.add_handler(handler)

--- a/src/python_italy_bot/services/captcha.py
+++ b/src/python_italy_bot/services/captcha.py
@@ -3,7 +3,13 @@
 import re
 from pathlib import Path
 
-from telegram import Chat, ChatPermissions, InlineKeyboardButton, InlineKeyboardMarkup, User
+from telegram import (
+    Chat,
+    ChatPermissions,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    User,
+)
 
 from .. import strings
 from ..db.base import AsyncRepository
@@ -49,7 +55,7 @@ class CaptchaService:
 
     def parse_button_urls(self, text: str) -> tuple[str, InlineKeyboardMarkup | None]:
         """Extract buttonurl:// patterns and build InlineKeyboardMarkup.
-        
+
         Returns (clean_text, keyboard) where clean_text has button syntax removed.
         Multiple buttons on the same line become the same row.
         """
@@ -160,3 +166,23 @@ class CaptchaService:
     async def is_globally_verified(self, user_id: int) -> bool:
         """Check if user is globally verified."""
         return await self._repo.is_globally_verified(user_id)
+
+    # -- Welcome-once-per-group --
+
+    async def has_been_welcomed(self, user_id: int, chat_id: int) -> bool:
+        """Check if user has already been welcomed in this chat."""
+        return await self._repo.has_been_welcomed(user_id, chat_id)
+
+    async def mark_welcomed(self, user_id: int, chat_id: int) -> None:
+        """Mark user as having been welcomed in this chat."""
+        await self._repo.mark_welcomed(user_id, chat_id)
+
+    # -- Welcome delay --
+
+    async def get_welcome_delay(self, chat_id: int) -> int | None:
+        """Get welcome message auto-delete delay in minutes for a chat."""
+        return await self._repo.get_welcome_delay(chat_id)
+
+    async def set_welcome_delay(self, chat_id: int, minutes: int | None) -> None:
+        """Set welcome message auto-delete delay. None to reset to default."""
+        await self._repo.set_welcome_delay(chat_id, minutes)

--- a/src/python_italy_bot/services/moderation.py
+++ b/src/python_italy_bot/services/moderation.py
@@ -3,6 +3,7 @@
 from telegram import ChatPermissions
 
 from ..db.base import AsyncRepository
+from ..db.models import KnownUser
 
 
 class ModerationService:
@@ -105,3 +106,19 @@ class ModerationService:
             message_id=message_id,
             reason=reason,
         )
+
+    # -- Known users (user tracking) --
+
+    async def upsert_known_user(
+        self,
+        user_id: int,
+        username: str | None,
+        first_name: str | None,
+        last_name: str | None,
+    ) -> None:
+        """Insert or update a known user's info."""
+        await self._repo.upsert_known_user(user_id, username, first_name, last_name)
+
+    async def get_known_user_by_username(self, username: str) -> KnownUser | None:
+        """Get a known user by username (case-insensitive)."""
+        return await self._repo.get_known_user_by_username(username)

--- a/src/python_italy_bot/strings.py
+++ b/src/python_italy_bot/strings.py
@@ -101,7 +101,7 @@ def ban_notification(
 
 
 # Unban
-UNBAN_USAGE = "Uso: /unban user_id, o rispondi al messaggio con /unban"
+UNBAN_USAGE = "Uso: /unban user_id|@username, o rispondi al messaggio con /unban"
 
 
 def unban_success(success_count: int, fail_count: int) -> str:

--- a/src/python_italy_bot/strings.py
+++ b/src/python_italy_bot/strings.py
@@ -4,6 +4,8 @@ All user-facing Italian strings for the bot, themed around Matrix (Neo/Electus)
 and Python programming metaphors.
 """
 
+import html
+
 BOT_NAME = "Electus"
 
 # =============================================================================
@@ -90,13 +92,15 @@ def ban_notification(
     reason: str | None,
 ) -> str:
     """Format ban notification message for admins."""
-    text = f"<b>{chat_title}:</b>\n"
-    text += f'Utente bannato: <a href="tg://user?id={banned_id}">{banned_name}</a> ({banned_id})\n'
-    text += (
-        f'Bannato da: <a href="tg://user?id={admin_id}">{admin_name}</a> ({admin_id})\n'
-    )
+    safe_chat_title = html.escape(chat_title, quote=True)
+    safe_banned_name = html.escape(banned_name, quote=True)
+    safe_admin_name = html.escape(admin_name, quote=True)
+    safe_reason = html.escape(reason, quote=True) if reason else "Nessuno"
+    text = f"<b>{safe_chat_title}:</b>\n"
+    text += f'Utente bannato: <a href="tg://user?id={banned_id}">{safe_banned_name}</a> ({banned_id})\n'
+    text += f'Bannato da: <a href="tg://user?id={admin_id}">{safe_admin_name}</a> ({admin_id})\n'
     text += f"Gruppi: {success_count}\n"
-    text += f"Motivo: {reason or 'Nessuno'}"
+    text += f"Motivo: {safe_reason}"
     return text
 
 

--- a/src/python_italy_bot/strings.py
+++ b/src/python_italy_bot/strings.py
@@ -21,8 +21,7 @@ VERIFY_READ_RULES_URL = (
 )
 
 VERIFY_READ_RULES_CONTENT = (
-    "Ecco il regolamento. Leggilo e invia il comando segreto che troverai:\n\n"
-    "{content}"
+    "Ecco il regolamento. Leggilo e invia il comando segreto che troverai:\n\n{content}"
 )
 
 VERIFY_SEND_SECRET = "Invia il comando segreto per completare la verifica."
@@ -36,14 +35,13 @@ VERIFY_NO_PENDING = (
     "Se hai appena completato la verifica, potrebbe essere già stata applicata."
 )
 
-VERIFY_SUCCESS = (
-    "Verifica completata. Accesso concesso alla comunità Python Italia."
-)
+VERIFY_SUCCESS = "Verifica completata. Accesso concesso alla comunità Python Italia."
 
 VERIFY_UNKNOWN_COMMAND = (
     "Comando non riconosciuto. Leggi il regolamento "
     "e invia il comando segreto che troverai."
 )
+
 
 def get_default_welcome_template(bot_username: str) -> str:
     """Return the default welcome message template with Matrix/Python flair."""
@@ -67,7 +65,11 @@ USER_NOT_FOUND = "Utente non trovato."
 GROUP_REGISTERED = "Gruppo registrato. Chat ID: {chat_id}"
 
 # Ban
-BAN_USAGE = "Uso: /ban user_id [motivo], o rispondi al messaggio con /ban [motivo]."
+BAN_USAGE = (
+    "Uso: /ban user_id|@username [motivo], "
+    "o rispondi a un messaggio (anche di benvenuto) con /ban [motivo]."
+)
+
 
 def ban_success(success_count: int, fail_count: int, reason: str | None) -> str:
     """Format ban success message."""
@@ -77,8 +79,30 @@ def ban_success(success_count: int, fail_count: int, reason: str | None) -> str:
     msg += f"\nMotivo: {reason or 'Nessuno'}"
     return msg
 
+
+def ban_notification(
+    chat_title: str,
+    banned_name: str,
+    banned_id: int,
+    admin_name: str,
+    admin_id: int,
+    success_count: int,
+    reason: str | None,
+) -> str:
+    """Format ban notification message for admins."""
+    text = f"<b>{chat_title}:</b>\n"
+    text += f'Utente bannato: <a href="tg://user?id={banned_id}">{banned_name}</a> ({banned_id})\n'
+    text += (
+        f'Bannato da: <a href="tg://user?id={admin_id}">{admin_name}</a> ({admin_id})\n'
+    )
+    text += f"Gruppi: {success_count}\n"
+    text += f"Motivo: {reason or 'Nessuno'}"
+    return text
+
+
 # Unban
 UNBAN_USAGE = "Uso: /unban user_id, o rispondi al messaggio con /unban"
+
 
 def unban_success(success_count: int, fail_count: int) -> str:
     """Format unban success message."""
@@ -87,8 +111,10 @@ def unban_success(success_count: int, fail_count: int) -> str:
         msg += f" ({fail_count} falliti)"
     return msg
 
+
 # Mute
 MUTE_USAGE = "Uso: /mute @username [minuti] [motivo], o rispondi al messaggio"
+
 
 def mute_success(duration: int | None, reason: str | None) -> str:
     """Format mute success message."""
@@ -98,6 +124,7 @@ def mute_success(duration: int | None, reason: str | None) -> str:
     if reason:
         msg += f". Motivo: {reason}"
     return msg
+
 
 MUTE_FAILED = "Impossibile mutare l'utente."
 
@@ -131,6 +158,19 @@ RESETWELCOME_SUCCESS = "Messaggio di benvenuto ripristinato al default."
 GETWELCOME_CUSTOM = "Messaggio di benvenuto attuale:\n\n{message}"
 GETWELCOME_DEFAULT = "Nessun messaggio personalizzato. Default:\n\n{message}"
 
+# Welcome delay
+SETWELCOMEDELAY_USAGE = "Uso: /setwelcomedelay <minuti> (0 per disattivare)"
+SETWELCOMEDELAY_SUCCESS = (
+    "Ritardo cancellazione messaggio di benvenuto impostato a {minutes} minuti."
+)
+SETWELCOMEDELAY_DISABLED = (
+    "Cancellazione automatica del messaggio di benvenuto disattivata."
+)
+GETWELCOMEDELAY_RESPONSE = (
+    "Ritardo cancellazione messaggio di benvenuto: {minutes} minuti."
+)
+GETWELCOMEDELAY_DEFAULT = "Nessun ritardo configurato. Default: 5 minuti."
+
 
 # =============================================================================
 # ID COMMAND
@@ -146,12 +186,12 @@ ID_RESPONSE = "ID chat: {chat_id}\nID utente: {user_id}"
 ANNOUNCE_OWNER_ONLY = "Solo il proprietario del bot può usare questo comando."
 ANNOUNCE_NO_OWNER_CONFIGURED = "BOT_OWNER_ID non configurato."
 ANNOUNCE_USAGE = (
-    "Uso: /announce <messaggio>\n\n"
-    "Supporta HTML e bottoni: [Testo](buttonurl://url)"
+    "Uso: /announce <messaggio>\n\nSupporta HTML e bottoni: [Testo](buttonurl://url)"
 )
 ANNOUNCE_EMPTY_MESSAGE = "Il messaggio non può essere vuoto."
 ANNOUNCE_NO_GROUPS = "Nessun gruppo registrato."
 ANNOUNCE_SENDING = "Invio annuncio a {count} gruppi..."
+
 
 def announce_result(success: int, failed: int) -> str:
     """Format announcement result message."""


### PR DESCRIPTION
## Goal

Implement 5 new features for the Python Italy Telegram Bot (a Telegram group management bot with captcha verification, moderation, and welcome messages):
1. Auto-delete welcome messages after X minutes (configurable per-group, default 5 min)
2. Track every user the bot interacts with (user_id, username, first_name, last_name)
3. Welcome message only once per user per group (if user leaves and re-joins, skip welcome)
4. Ban by replying to welcome message + ban by @handle (not just user_id or direct reply)
5. Ban notifies group admins via DM (same pattern as existing /report notifications)