### PR TITLE
feat: targeted announce

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS globally_verified_users (
 
 CREATE TABLE IF NOT EXISTS bot_chats (
     chat_id BIGINT PRIMARY KEY,
+    title TEXT,
     added_at TIMESTAMPTZ DEFAULT NOW()
 );
 
@@ -87,3 +88,7 @@ CREATE TABLE IF NOT EXISTS welcomed_users (
 -- Add welcome_delay_minutes column to group_settings (idempotent).
 ALTER TABLE group_settings
     ADD COLUMN IF NOT EXISTS welcome_delay_minutes INTEGER;
+
+-- Add title column to bot_chats for group name lookup (idempotent).
+ALTER TABLE bot_chats
+    ADD COLUMN IF NOT EXISTS title TEXT;

--- a/src/python_italy_bot/db/__init__.py
+++ b/src/python_italy_bot/db/__init__.py
@@ -2,7 +2,7 @@
 
 from .base import AsyncRepository, Repository
 from .in_memory import InMemoryRepository
-from .models import Ban, Mute, Report
+from .models import Ban, Chat, Mute, Report
 from .postgres import PostgresRepository
 
 __all__ = [
@@ -11,6 +11,7 @@ __all__ = [
     "InMemoryRepository",
     "PostgresRepository",
     "Ban",
+    "Chat",
     "Mute",
     "Report",
     "create_repository",

--- a/src/python_italy_bot/db/base.py
+++ b/src/python_italy_bot/db/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from .models import KnownUser
+from .models import Chat, KnownUser
 
 
 class Repository(ABC):
@@ -109,13 +109,23 @@ class Repository(ABC):
         ...
 
     @abstractmethod
-    def register_chat(self, chat_id: int) -> None:
+    def register_chat(self, chat_id: int, title: str | None = None) -> None:
         """Track a chat where the bot is active."""
         ...
 
     @abstractmethod
     def get_all_chats(self) -> list[int]:
         """Get all tracked chat IDs."""
+        ...
+
+    @abstractmethod
+    def get_all_chats_with_titles(self) -> list[Chat]:
+        """Get all tracked chats with their titles."""
+        ...
+
+    @abstractmethod
+    def find_chats_by_title(self, query: str) -> list[Chat]:
+        """Find tracked chats whose title contains the query (case-insensitive)."""
         ...
 
     @abstractmethod
@@ -290,13 +300,23 @@ class AsyncRepository(ABC):
         ...
 
     @abstractmethod
-    async def register_chat(self, chat_id: int) -> None:
+    async def register_chat(self, chat_id: int, title: str | None = None) -> None:
         """Track a chat where the bot is active."""
         ...
 
     @abstractmethod
     async def get_all_chats(self) -> list[int]:
         """Get all tracked chat IDs."""
+        ...
+
+    @abstractmethod
+    async def get_all_chats_with_titles(self) -> list[Chat]:
+        """Get all tracked chats with their titles."""
+        ...
+
+    @abstractmethod
+    async def find_chats_by_title(self, query: str) -> list[Chat]:
+        """Find tracked chats whose title contains the query (case-insensitive)."""
         ...
 
     @abstractmethod

--- a/src/python_italy_bot/db/in_memory.py
+++ b/src/python_italy_bot/db/in_memory.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 
 from .base import AsyncRepository
-from .models import Ban, KnownUser, Mute, Report
+from .models import Ban, Chat, KnownUser, Mute, Report
 
 
 class InMemoryRepository(AsyncRepository):
@@ -17,7 +17,7 @@ class InMemoryRepository(AsyncRepository):
         self._reports: list[Report] = []
         self._welcome_messages: dict[int, str] = {}
         self._globally_verified: set[int] = set()
-        self._bot_chats: set[int] = set()
+        self._bot_chats: dict[int, str | None] = {}
         self._global_bans: dict[int, tuple[int, str | None]] = {}
         self._known_users: dict[int, KnownUser] = {}
         self._username_to_user_id: dict[str, int] = {}
@@ -141,11 +141,22 @@ class InMemoryRepository(AsyncRepository):
     async def mark_globally_verified(self, user_id: int) -> None:
         self._globally_verified.add(user_id)
 
-    async def register_chat(self, chat_id: int) -> None:
-        self._bot_chats.add(chat_id)
+    async def register_chat(self, chat_id: int, title: str | None = None) -> None:
+        self._bot_chats[chat_id] = title
 
     async def get_all_chats(self) -> list[int]:
-        return list(self._bot_chats)
+        return list(self._bot_chats.keys())
+
+    async def get_all_chats_with_titles(self) -> list[Chat]:
+        return [Chat(chat_id=cid, title=t) for cid, t in self._bot_chats.items()]
+
+    async def find_chats_by_title(self, query: str) -> list[Chat]:
+        query_lower = query.lower()
+        return [
+            Chat(chat_id=cid, title=t)
+            for cid, t in self._bot_chats.items()
+            if t and query_lower in t.lower()
+        ]
 
     async def add_global_ban(
         self,

--- a/src/python_italy_bot/db/models.py
+++ b/src/python_italy_bot/db/models.py
@@ -48,3 +48,11 @@ class Report:
     message_id: int | None
     reason: str | None
     created_at: datetime
+
+
+@dataclass
+class Chat:
+    """A tracked chat where the bot is active."""
+
+    chat_id: int
+    title: str | None

--- a/src/python_italy_bot/db/postgres.py
+++ b/src/python_italy_bot/db/postgres.py
@@ -3,7 +3,7 @@
 from psycopg_pool import AsyncConnectionPool
 
 from .base import AsyncRepository
-from .models import KnownUser
+from .models import Chat, KnownUser
 
 
 class PostgresRepository(AsyncRepository):
@@ -208,15 +208,15 @@ class PostgresRepository(AsyncRepository):
                 (user_id,),
             )
 
-    async def register_chat(self, chat_id: int) -> None:
+    async def register_chat(self, chat_id: int, title: str | None = None) -> None:
         async with self._pool.connection() as conn:
             await conn.execute(
                 """
-                INSERT INTO bot_chats (chat_id)
-                VALUES (%s)
-                ON CONFLICT (chat_id) DO NOTHING
+                INSERT INTO bot_chats (chat_id, title)
+                VALUES (%s, %s)
+                ON CONFLICT (chat_id) DO UPDATE SET title = EXCLUDED.title
                 """,
-                (chat_id,),
+                (chat_id, title),
             )
 
     async def get_all_chats(self) -> list[int]:
@@ -225,6 +225,25 @@ class PostgresRepository(AsyncRepository):
                 await cur.execute("SELECT chat_id FROM bot_chats")
                 rows = await cur.fetchall()
                 return [row[0] for row in rows]
+
+    async def get_all_chats_with_titles(self) -> list[Chat]:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT chat_id, title FROM bot_chats ORDER BY chat_id"
+                )
+                rows = await cur.fetchall()
+                return [Chat(chat_id=row[0], title=row[1]) for row in rows]
+
+    async def find_chats_by_title(self, query: str) -> list[Chat]:
+        async with self._pool.connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT chat_id, title FROM bot_chats WHERE title ILIKE %s",
+                    (f"%{query}%",),
+                )
+                rows = await cur.fetchall()
+                return [Chat(chat_id=row[0], title=row[1]) for row in rows]
 
     async def add_global_ban(
         self,

--- a/src/python_italy_bot/handlers/announce.py
+++ b/src/python_italy_bot/handlers/announce.py
@@ -1,12 +1,14 @@
-"""Handler for broadcasting announcements to all groups."""
+"""Handler for broadcasting announcements to groups."""
 
 import logging
+import re
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import CommandHandler, ContextTypes
 
 from .. import strings
 from ..config import Settings
+from ..db.models import Chat
 from ..services.captcha import BUTTON_URL_PATTERN
 from ..services.moderation import ModerationService
 
@@ -27,8 +29,7 @@ def _parse_button_urls(text: str) -> tuple[str, InlineKeyboardMarkup | None]:
         matches = list(BUTTON_URL_PATTERN.finditer(line))
         if matches:
             row = [
-                InlineKeyboardButton(text=m.group(1), url=m.group(2))
-                for m in matches
+                InlineKeyboardButton(text=m.group(1), url=m.group(2)) for m in matches
             ]
             keyboard_rows.append(row)
             clean_line = BUTTON_URL_PATTERN.sub("", line).strip()
@@ -42,16 +43,76 @@ def _parse_button_urls(text: str) -> tuple[str, InlineKeyboardMarkup | None]:
     return clean_text, keyboard
 
 
+def _parse_target_and_message(raw_announcement: str) -> tuple[str | None, str]:
+    """Split 'target | message' into (target, message).
+
+    If no pipe separator is found, returns (None, raw_announcement).
+    Only the first pipe is used as delimiter.
+    """
+    if "|" in raw_announcement:
+        target, _, message = raw_announcement.partition("|")
+        target = target.strip()
+        message = message.strip()
+        if target and message:
+            return target, message
+    return None, raw_announcement
+
+
+async def _resolve_target_chats(
+    target: str,
+    moderation_service: ModerationService,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> list[Chat] | str:
+    """Resolve a target string to a list of Chat objects.
+
+    Returns a list of Chat on success, or an error message string on failure.
+    Resolution order:
+      1. Numeric ID -> direct lookup
+      2. @username -> Telegram API get_chat
+      3. Otherwise -> search registered chats by title
+    """
+    # 1. Numeric ID
+    if re.match(r"^-?\d+$", target):
+        chat_id = int(target)
+        # Check if it's a registered chat
+        all_chats = await moderation_service.get_all_chats_with_titles()
+        for chat in all_chats:
+            if chat.chat_id == chat_id:
+                return [chat]
+        # Not registered but still try to send (owner might know the ID)
+        return [Chat(chat_id=chat_id, title=None)]
+
+    # 2. @username -> resolve via Telegram API
+    if target.startswith("@"):
+        try:
+            resolved = await context.bot.get_chat(target)
+            return [Chat(chat_id=resolved.id, title=resolved.title)]
+        except Exception:
+            return strings.ANNOUNCE_GROUP_NOT_FOUND.format(target=target)
+
+    # 3. Search by title
+    matches = await moderation_service.find_chats_by_title(target)
+    if not matches:
+        return strings.ANNOUNCE_GROUP_NOT_FOUND.format(target=target)
+    if len(matches) > 1:
+        match_lines = "\n".join(f"  {c.chat_id} — {c.title}" for c in matches)
+        return strings.ANNOUNCE_AMBIGUOUS_GROUPS.format(
+            query=target, matches=match_lines
+        )
+    return matches
+
+
 async def _handle_announce(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
     moderation_service: ModerationService,
     settings: Settings,
 ) -> None:
-    """Broadcast an announcement to all registered groups.
+    """Broadcast an announcement to all or a specific group.
 
     Only works in DM and only for the bot owner.
     Supports HTML formatting and [text](buttonurl://url) button syntax.
+    Use pipe syntax to target: /announce target | message
     """
     message = update.effective_message
     chat = update.effective_chat
@@ -79,27 +140,40 @@ async def _handle_announce(
         await message.reply_text(strings.ANNOUNCE_USAGE)
         return
 
-    clean_text, keyboard = _parse_button_urls(announcement)
+    target_str, body = _parse_target_and_message(announcement)
+
+    clean_text, keyboard = _parse_button_urls(body)
 
     if not clean_text:
         await message.reply_text(strings.ANNOUNCE_EMPTY_MESSAGE)
         return
 
-    chat_ids = await moderation_service.get_all_chats()
-
-    if not chat_ids:
-        await message.reply_text(strings.ANNOUNCE_NO_GROUPS)
-        return
-
-    await message.reply_text(strings.ANNOUNCE_SENDING.format(count=len(chat_ids)))
+    # Resolve target chat(s)
+    if target_str is not None:
+        result = await _resolve_target_chats(target_str, moderation_service, context)
+        if isinstance(result, str):
+            await message.reply_text(result)
+            return
+        target_chats = result
+        display_name = target_chats[0].title or str(target_chats[0].chat_id)
+        await message.reply_text(
+            strings.ANNOUNCE_SENDING_TARGETED.format(name=display_name)
+        )
+        chat_ids = [c.chat_id for c in target_chats]
+    else:
+        chat_ids = await moderation_service.get_all_chats()
+        if not chat_ids:
+            await message.reply_text(strings.ANNOUNCE_NO_GROUPS)
+            return
+        await message.reply_text(strings.ANNOUNCE_SENDING.format(count=len(chat_ids)))
 
     success = 0
     failed = 0
 
-    for chat_id in chat_ids:
+    for cid in chat_ids:
         try:
             await context.bot.send_message(
-                chat_id=chat_id,
+                chat_id=cid,
                 text=clean_text,
                 parse_mode="HTML",
                 reply_markup=keyboard,
@@ -107,19 +181,67 @@ async def _handle_announce(
             success += 1
         except Exception as e:
             failed += 1
-            logger.warning("Failed to send announcement to %s: %s", chat_id, e)
+            logger.warning("Failed to send announcement to %s: %s", cid, e)
 
     await message.reply_text(strings.announce_result(success, failed))
+
+
+async def _handle_groups(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    moderation_service: ModerationService,
+    settings: Settings,
+) -> None:
+    """List all registered groups. Owner only, private chat only."""
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+
+    if not message or not chat or not user:
+        return
+
+    if chat.type != "private":
+        await message.reply_text(strings.ONLY_IN_PRIVATE)
+        return
+
+    if settings.bot_owner_id is None:
+        await message.reply_text(strings.ANNOUNCE_NO_OWNER_CONFIGURED)
+        return
+
+    if user.id != settings.bot_owner_id:
+        await message.reply_text(strings.ANNOUNCE_OWNER_ONLY)
+        return
+
+    chats = await moderation_service.get_all_chats_with_titles()
+
+    if not chats:
+        await message.reply_text(strings.GROUPS_LIST_EMPTY)
+        return
+
+    lines = [strings.GROUPS_LIST_HEADER.format(count=len(chats))]
+    for c in chats:
+        title = c.title or "(senza nome)"
+        lines.append(strings.GROUPS_LIST_ROW.format(chat_id=c.chat_id, title=title))
+
+    await message.reply_text("\n".join(lines))
 
 
 def create_announce_handlers(
     moderation_service: ModerationService, settings: Settings
 ) -> list[CommandHandler]:
-    """Create handlers for the announce command."""
+    """Create handlers for the announce and groups commands."""
 
     async def announce_wrapper(
         update: Update, context: ContextTypes.DEFAULT_TYPE
     ) -> None:
         await _handle_announce(update, context, moderation_service, settings)
 
-    return [CommandHandler("announce", announce_wrapper)]
+    async def groups_wrapper(
+        update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        await _handle_groups(update, context, moderation_service, settings)
+
+    return [
+        CommandHandler("announce", announce_wrapper),
+        CommandHandler("groups", groups_wrapper),
+    ]

--- a/src/python_italy_bot/handlers/moderation.py
+++ b/src/python_italy_bot/handlers/moderation.py
@@ -64,7 +64,7 @@ async def _handle_force_group_registration(
         await message.reply_text(strings.ONLY_ADMINS)
         return
 
-    await moderation_service.register_chat(chat.id)
+    await moderation_service.register_chat(chat.id, chat.title)
     await message.reply_text(strings.GROUP_REGISTERED.format(chat_id=chat.id))
 
 

--- a/src/python_italy_bot/handlers/welcome.py
+++ b/src/python_italy_bot/handlers/welcome.py
@@ -82,7 +82,7 @@ async def _handle_new_member(
     if user is None or chat is None:
         return
 
-    await moderation_service.register_chat(chat.id)
+    await moderation_service.register_chat(chat.id, chat.title)
 
     # Track the new member explicitly: middleware tracks effective_user (the admin
     # when someone is added by an admin), but we need to track the joined member.

--- a/src/python_italy_bot/services/moderation.py
+++ b/src/python_italy_bot/services/moderation.py
@@ -3,7 +3,7 @@
 from telegram import ChatPermissions
 
 from ..db.base import AsyncRepository
-from ..db.models import KnownUser
+from ..db.models import Chat, KnownUser
 
 
 class ModerationService:
@@ -61,13 +61,21 @@ class ModerationService:
         """Check if user is globally banned."""
         return await self._repo.is_globally_banned(user_id)
 
-    async def register_chat(self, chat_id: int) -> None:
+    async def register_chat(self, chat_id: int, title: str | None = None) -> None:
         """Register a chat where the bot is active."""
-        await self._repo.register_chat(chat_id)
+        await self._repo.register_chat(chat_id, title)
 
     async def get_all_chats(self) -> list[int]:
         """Get all tracked chat IDs."""
         return await self._repo.get_all_chats()
+
+    async def get_all_chats_with_titles(self) -> list[Chat]:
+        """Get all tracked chats with their titles."""
+        return await self._repo.get_all_chats_with_titles()
+
+    async def find_chats_by_title(self, query: str) -> list[Chat]:
+        """Find tracked chats whose title contains the query (case-insensitive)."""
+        return await self._repo.find_chats_by_title(query)
 
     async def add_mute(
         self,

--- a/src/python_italy_bot/strings.py
+++ b/src/python_italy_bot/strings.py
@@ -190,11 +190,24 @@ ID_RESPONSE = "ID chat: {chat_id}\nID utente: {user_id}"
 ANNOUNCE_OWNER_ONLY = "Solo il proprietario del bot può usare questo comando."
 ANNOUNCE_NO_OWNER_CONFIGURED = "BOT_OWNER_ID non configurato."
 ANNOUNCE_USAGE = (
-    "Uso: /announce <messaggio>\n\nSupporta HTML e bottoni: [Testo](buttonurl://url)"
+    "Uso: /announce <messaggio>\n"
+    "Uso mirato: /announce <gruppo> | <messaggio>\n\n"
+    "Il gruppo può essere un ID numerico, @username o nome del gruppo.\n"
+    "Supporta HTML e bottoni: [Testo](buttonurl://url)"
 )
 ANNOUNCE_EMPTY_MESSAGE = "Il messaggio non può essere vuoto."
 ANNOUNCE_NO_GROUPS = "Nessun gruppo registrato."
 ANNOUNCE_SENDING = "Invio annuncio a {count} gruppi..."
+ANNOUNCE_SENDING_TARGETED = "Invio annuncio a {name}..."
+ANNOUNCE_GROUP_NOT_FOUND = "Gruppo non trovato: {target}"
+ANNOUNCE_AMBIGUOUS_GROUPS = (
+    'Più gruppi corrispondono a "{query}":\n{matches}\n\n'
+    "Specifica l'ID del gruppo per evitare ambiguità."
+)
+
+GROUPS_LIST_HEADER = "Gruppi registrati ({count}):"
+GROUPS_LIST_ROW = "  {chat_id} — {title}"
+GROUPS_LIST_EMPTY = "Nessun gruppo registrato."
 
 
 def announce_result(success: int, failed: int) -> str:

--- a/tests/test_announce.py
+++ b/tests/test_announce.py
@@ -1,0 +1,173 @@
+"""Tests for InMemoryRepository chat methods and announce target parsing."""
+
+import asyncio
+
+from python_italy_bot.db.in_memory import InMemoryRepository
+from python_italy_bot.handlers.announce import _parse_target_and_message
+from python_italy_bot.services.moderation import ModerationService
+
+
+# -- InMemoryRepository tests --
+
+
+def test_register_chat_without_title() -> None:
+    """Register a chat without title stores None."""
+    repo = InMemoryRepository()
+    asyncio.run(repo.register_chat(-100123))
+    chats = asyncio.run(repo.get_all_chats())
+    assert chats == [-100123]
+
+
+def test_register_chat_with_title() -> None:
+    """Register a chat with title stores both."""
+    repo = InMemoryRepository()
+    asyncio.run(repo.register_chat(-100123, "Python Italia"))
+    chats = asyncio.run(repo.get_all_chats_with_titles())
+    assert len(chats) == 1
+    assert chats[0].chat_id == -100123
+    assert chats[0].title == "Python Italia"
+
+
+def test_register_chat_updates_title() -> None:
+    """Re-registering a chat updates its title."""
+    repo = InMemoryRepository()
+    asyncio.run(repo.register_chat(-100123, "Old Name"))
+    asyncio.run(repo.register_chat(-100123, "New Name"))
+    chats = asyncio.run(repo.get_all_chats_with_titles())
+    assert len(chats) == 1
+    assert chats[0].title == "New Name"
+
+
+def test_get_all_chats_returns_ids_only() -> None:
+    """get_all_chats returns only chat IDs."""
+    repo = InMemoryRepository()
+    asyncio.run(repo.register_chat(-100001, "Group A"))
+    asyncio.run(repo.register_chat(-100002, "Group B"))
+    chats = asyncio.run(repo.get_all_chats())
+    assert set(chats) == {-100001, -100002}
+
+
+def test_get_all_chats_with_titles_returns_chat_objects() -> None:
+    """get_all_chats_with_titles returns Chat dataclass instances."""
+    repo = InMemoryRepository()
+    asyncio.run(repo.register_chat(-100001, "Group A"))
+    asyncio.run(repo.register_chat(-100002))
+    chats = asyncio.run(repo.get_all_chats_with_titles())
+    assert len(chats) == 2
+    by_id = {c.chat_id: c for c in chats}
+    assert by_id[-100001].title == "Group A"
+    assert by_id[-100002].title is None
+
+
+def test_find_chats_by_title_case_insensitive() -> None:
+    """find_chats_by_title matches case-insensitively."""
+    repo = InMemoryRepository()
+    asyncio.run(repo.register_chat(-100001, "Python Italia"))
+    asyncio.run(repo.register_chat(-100002, "Python Torino"))
+    asyncio.run(repo.register_chat(-100003, "JavaScript Italia"))
+
+    results = asyncio.run(repo.find_chats_by_title("python"))
+    assert len(results) == 2
+    ids = {c.chat_id for c in results}
+    assert ids == {-100001, -100002}
+
+
+def test_find_chats_by_title_partial_match() -> None:
+    """find_chats_by_title matches partial strings."""
+    repo = InMemoryRepository()
+    asyncio.run(repo.register_chat(-100001, "Python Italia"))
+    results = asyncio.run(repo.find_chats_by_title("Ital"))
+    assert len(results) == 1
+    assert results[0].chat_id == -100001
+
+
+def test_find_chats_by_title_no_match() -> None:
+    """find_chats_by_title returns empty list when no match."""
+    repo = InMemoryRepository()
+    asyncio.run(repo.register_chat(-100001, "Python Italia"))
+    results = asyncio.run(repo.find_chats_by_title("Rust"))
+    assert results == []
+
+
+def test_find_chats_by_title_skips_none_titles() -> None:
+    """find_chats_by_title skips chats without a title."""
+    repo = InMemoryRepository()
+    asyncio.run(repo.register_chat(-100001))
+    results = asyncio.run(repo.find_chats_by_title("anything"))
+    assert results == []
+
+
+# -- ModerationService delegation tests --
+
+
+def test_moderation_service_register_chat_with_title() -> None:
+    """ModerationService.register_chat forwards title to repository."""
+    repo = InMemoryRepository()
+    service = ModerationService(repo)
+    asyncio.run(service.register_chat(-100001, "Test Group"))
+    chats = asyncio.run(service.get_all_chats_with_titles())
+    assert len(chats) == 1
+    assert chats[0].title == "Test Group"
+
+
+def test_moderation_service_find_chats_by_title() -> None:
+    """ModerationService.find_chats_by_title delegates to repository."""
+    repo = InMemoryRepository()
+    service = ModerationService(repo)
+    asyncio.run(service.register_chat(-100001, "Python Italia"))
+    asyncio.run(service.register_chat(-100002, "Python Torino"))
+    results = asyncio.run(service.find_chats_by_title("Torino"))
+    assert len(results) == 1
+    assert results[0].chat_id == -100002
+
+
+# -- Target parsing tests --
+
+
+def test_parse_target_and_message_with_pipe() -> None:
+    """Pipe separator splits target from message."""
+    target, message = _parse_target_and_message("Python Italia | Hello everyone!")
+    assert target == "Python Italia"
+    assert message == "Hello everyone!"
+
+
+def test_parse_target_and_message_without_pipe() -> None:
+    """No pipe means no target, full text is message."""
+    target, message = _parse_target_and_message("Hello everyone!")
+    assert target is None
+    assert message == "Hello everyone!"
+
+
+def test_parse_target_and_message_numeric_id() -> None:
+    """Numeric target with pipe."""
+    target, message = _parse_target_and_message("-100123 | Announcement")
+    assert target == "-100123"
+    assert message == "Announcement"
+
+
+def test_parse_target_and_message_username() -> None:
+    """Username target with pipe."""
+    target, message = _parse_target_and_message("@pythonita | News update")
+    assert target == "@pythonita"
+    assert message == "News update"
+
+
+def test_parse_target_and_message_pipe_in_message() -> None:
+    """Only the first pipe is used as delimiter."""
+    target, message = _parse_target_and_message("group | msg with | pipe")
+    assert target == "group"
+    assert message == "msg with | pipe"
+
+
+def test_parse_target_and_message_empty_target() -> None:
+    """Empty target before pipe falls back to no-target mode."""
+    target, message = _parse_target_and_message(" | Hello")
+    assert target is None
+    assert message == " | Hello"
+
+
+def test_parse_target_and_message_empty_message() -> None:
+    """Empty message after pipe falls back to no-target mode."""
+    target, message = _parse_target_and_message("group | ")
+    assert target is None
+    assert message == "group | "


### PR DESCRIPTION
The user wants to add a targeted announce feature to their Python Italy Telegram Bot. The /announce command should support sending announcements to a specific group by group ID or group name, in addition to the existing broadcast-to-all behavior.