### PR TITLE
Change /unmute command so that the exception on permissions is dropped

### DIFF
--- a/src/python_italy_bot/handlers/moderation.py
+++ b/src/python_italy_bot/handlers/moderation.py
@@ -362,14 +362,16 @@ async def _handle_unmute(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         can_send_polls=True,
         can_send_other_messages=True,
         can_add_web_page_previews=True,
-        can_change_info=False,
+        can_change_info=True,
         can_invite_users=True,
-        can_pin_messages=False,
+        can_pin_messages=True,
     )
 
     try:
         await context.bot.restrict_chat_member(chat.id, user_id, full_perms)
         await moderation_service.remove_mute(user_id, chat.id)
+        captcha_service: CaptchaService = context.bot_data["captcha_service"]
+        await captcha_service.verify_user_globally(user_id)
         await message.reply_text(strings.UNMUTE_SUCCESS)
     except Exception as e:
         logger.warning("Unmute failed: %s", e)

--- a/src/python_italy_bot/services/captcha.py
+++ b/src/python_italy_bot/services/captcha.py
@@ -132,9 +132,9 @@ class CaptchaService:
             can_send_polls=True,
             can_send_other_messages=True,
             can_add_web_page_previews=True,
-            can_change_info=False,
+            can_change_info=True,
             can_invite_users=True,
-            can_pin_messages=False,
+            can_pin_messages=True,
         )
 
     def is_secret_command(self, text: str) -> bool:


### PR DESCRIPTION
## Why

I've 4 stale users sitting in a muted state forever in the [@PythonMilano](https://t.me/PythonMilano) telegram channel.

Behavior

I'm experiencing This. 
The captcha for new user maybe was not displayed, but for sure is not displayed if a user leave the group and then tries to subscribe again.
New users are subscribed but muted meaning that the default permission are overridden by exceptions for them. I suspect that the exception are not cleared from the bot database once a user unsubscribe. Another bug is that the `/unmute` command does not remove the exception, the result looks like a user is muted forever.

## How to test it

In the https://t.me/PythonMilano there are currently 4 stale users, I know this people personally and I want to un-mute them even if they do not clicked the captcha.

<!-- 
Other than reviewing the code, we also need to test it to make sure it works, use this space to write the steps to 
test the PR, validate what is the correct behavior and what is not and so on.

On the PyCon repo, you can also deploy your PR to staging commenting `/deploy` on this PR. 
But make sure that no-one else is using staging first!
!-->
